### PR TITLE
fix: update word-break style.

### DIFF
--- a/dw-snackbar.js
+++ b/dw-snackbar.js
@@ -138,7 +138,7 @@ export class DwSnackbar extends layoutMixin(LitElement) {
 
         .text {
           padding: 14px 16px;
-          word-break: break-all;
+          overflow-wrap: break-word;
         }
 
         dw-icon-button,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted text wrapping in the notification component for better readability by preserving whole words when content exceeds container width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->